### PR TITLE
feat : カード生成の際に、ファイル選択から生成できる機能を追加。

### DIFF
--- a/front/biome.json
+++ b/front/biome.json
@@ -7,7 +7,14 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**", "!node_modules", "!.next", "!dist", "!build"]
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build",
+      "!src/generated"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/front/src/app/(authorized)/camera/page.tsx
+++ b/front/src/app/(authorized)/camera/page.tsx
@@ -185,7 +185,9 @@ export default function CameraPage() {
       }
 
       // Upload to user-specific path: users/{userId}/cards/{filename}
-      const extension = selectedFile ? selectedFile.name.split('.').pop() : 'png';
+      const extension = selectedFile
+        ? selectedFile.name.split(".").pop()
+        : "png";
       const uploadPath = `users/${user.id}/cards/${timestamp}.${extension}`;
 
       const url = await uploadImage(file, uploadPath);
@@ -407,7 +409,15 @@ export default function CameraPage() {
                         strokeLinecap="round"
                         strokeLinejoin="round"
                       >
-                        <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+                        <title>画像アイコン</title>
+                        <rect
+                          width="18"
+                          height="18"
+                          x="3"
+                          y="3"
+                          rx="2"
+                          ry="2"
+                        />
                         <circle cx="9" cy="9" r="2" />
                         <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
                       </svg>
@@ -645,8 +655,6 @@ export default function CameraPage() {
           {/* アクションボタン（撮影後に表示） */}
           {capturedImage && (
             <>
-
-
               {/* カード化ボタン */}
               <button
                 type="button"


### PR DESCRIPTION
## 概要
カメラページにおいて、カメラ撮影だけでなくデバイス（フォトライブラリ等）から画像を選択してカード化できる機能を追加しました。
これにより、既存の写真や保存してある画像を使用して部員カードを作成することが可能になります。

## チケットへのリンク
（該当するIssueがあれば記入、なければ「特になし」）

## マージを希望するか
- [x] 希望する
- [ ] 希望しない

## 行った作業
- カメラページ (`/camera`) に画像選択用の `input type="file"` を追加
- カメラプレビューエリアに「画像を選択」ボタン（およびアイコン）を追加
- 選択された画像ファイルを Firebase Storage へアップロードするロジックの実装
- 選択した画像をプレビュー表示する機能の実装
- 撮影・画像選択後のUI調整（不要なボタンの削除など）

## 動作確認
* どのような動作確認を行ったのか？ 結果はどうか？
  * ローカル環境（PC）にて、フォルダから画像ファイル（.png, .jpg）を選択し、プレビューが表示されることを確認しました。
  * 「確定」および「カード化する」ボタン押下後、Firebase Storage へのアップロードが成功し、Firestore に正しい画像URLを含むカードデータが作成されることを確認しました。
  * 既存のカメラ撮影機能も問題なく動作することを確認しました。

## その他

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

* **新機能**
  * カメラキャプチャに加え、ギャラリー（ファイルピッカー）から画像を選択できるようになりました。

* **改善**
  * キャプチャ後のUIを整理し、選択フローを最適化しました（ファイル選択トリガーと区切り線の追加）。
  * 選択された画像の形式に応じてアップロード時の拡張子を自動判別するようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->