### PR TITLE
feat 推しメン選択機能追加

### DIFF
--- a/front/src/app/(authorized)/binder/BinderContent.tsx
+++ b/front/src/app/(authorized)/binder/BinderContent.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import type { Card } from "@/types/app";
+import { BinderGrid, FavoriteButton } from "./BinderGrid";
+
+interface BinderContentProps {
+  cards: Card[];
+}
+
+export function BinderContent({ cards }: BinderContentProps) {
+  const [isSelectingFavorite, setIsSelectingFavorite] = useState(false);
+
+  return (
+    <>
+      {/* Header */}
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-wide">マイ・バインダー</h1>
+          <p className="text-sm text-gray-400">Total Cards: {cards.length}</p>
+        </div>
+        {cards.length > 0 && (
+          <FavoriteButton
+            isSelectingFavorite={isSelectingFavorite}
+            onToggle={() => setIsSelectingFavorite(!isSelectingFavorite)}
+            disabled={false}
+          />
+        )}
+      </div>
+
+      {/* Empty State */}
+      {cards.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-20">
+          <div className="text-gray-400 text-center">
+            <svg
+              className="w-16 h-16 mx-auto mb-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-label="空のバインダーアイコン"
+            >
+              <title>空のバインダーアイコン</title>
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"
+              />
+            </svg>
+            <p className="text-lg font-semibold mb-2">カードがありません</p>
+            <p className="text-sm">
+              カメラから新しいカードを作成してみましょう！
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Grid */}
+      {cards.length > 0 && (
+        <BinderGrid
+          cards={cards}
+          isSelectingFavorite={isSelectingFavorite}
+          onFavoriteSelected={() => setIsSelectingFavorite(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/front/src/app/(authorized)/binder/BinderGrid.tsx
+++ b/front/src/app/(authorized)/binder/BinderGrid.tsx
@@ -44,11 +44,9 @@ export function BinderGrid({
   const handleCardClick = async (card: CardType) => {
     if (!user || processing) return;
 
-    // 推しメン登録モードの場合
     if (isSelectingFavorite) {
       const isFavorite = favoriteCardIds.includes(card.id);
 
-      // 既に推しメンの場合は何もしない
       if (isFavorite) {
         toast("既に推しメン登録済みです", {
           icon: "⭐",
@@ -60,11 +58,8 @@ export function BinderGrid({
 
       try {
         setProcessing(true);
-
-        // 推しメン登録（既存の推しメンは自動的に解除される）
         await addFavoriteCard(user.id, card.id);
-        setFavoriteCardIds([card.id]); // 1人のみ
-
+        setFavoriteCardIds([card.id]);
         toast.success(`${card.name}を推しメンに登録しました！`, {
           icon: "⭐",
           duration: 3000,
@@ -80,7 +75,6 @@ export function BinderGrid({
       return;
     }
 
-    // 通常モード：カード詳細に遷移
     toast("カード詳細ページは未実装です", {
       icon: "ℹ️",
       duration: 2000,
@@ -89,14 +83,11 @@ export function BinderGrid({
 
   return (
     <div>
-      {/* カードグリッド */}
       <div className="grid grid-cols-3 gap-3">
         {cards.map((card, index) => (
-          <button
+          <div
             key={card.id}
-            type="button"
-            onClick={() => handleCardClick(card)}
-            className={`cursor-pointer transition-all text-left ${
+            className={`transition-all ${
               processing ? "opacity-50 pointer-events-none" : ""
             } ${
               isSelectingFavorite
@@ -104,19 +95,23 @@ export function BinderGrid({
                 : ""
             }`}
           >
-            <Card card={card} label={getLabel(index)} />
+            <Card
+              card={card}
+              label={getLabel(index)}
+              onClick={() => handleCardClick(card)}
+            />
             {favoriteCardIds.includes(card.id) && (
               <div className="text-center text-yellow-400 text-xs mt-1">
                 ⭐ 推しメン
               </div>
             )}
-          </button>
+          </div>
         ))}
       </div>
     </div>
   );
 }
-// 推しメン登録ボタンコンポーネント
+
 export function FavoriteButton({
   isSelectingFavorite,
   onToggle,

--- a/front/src/app/(authorized)/binder/BinderGrid.tsx
+++ b/front/src/app/(authorized)/binder/BinderGrid.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import toast from "react-hot-toast";
+import Card from "@/components/Card";
+import { useAuth } from "@/context/AuthContext";
+import { addFavoriteCard, getFavoriteCards } from "@/lib/firestore";
+import type { Card as CardType } from "@/types/app";
+
+interface BinderGridProps {
+  cards: CardType[];
+  isSelectingFavorite: boolean;
+  onFavoriteSelected: () => void;
+}
+
+export function BinderGrid({
+  cards,
+  isSelectingFavorite,
+  onFavoriteSelected,
+}: BinderGridProps) {
+  const { user } = useAuth();
+  const [processing, setProcessing] = useState(false);
+  const [favoriteCardIds, setFavoriteCardIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    const loadFavorites = async () => {
+      if (!user) return;
+
+      try {
+        const favorites = await getFavoriteCards(user.id);
+        setFavoriteCardIds(favorites.map((card) => card.id));
+      } catch (error) {
+        console.error("Failed to load favorites:", error);
+      }
+    };
+
+    loadFavorites();
+  }, [user]);
+
+  const getLabel = (index: number): string | undefined => {
+    return index < 3 ? "1st" : undefined;
+  };
+
+  const handleCardClick = async (card: CardType) => {
+    if (!user || processing) return;
+
+    // 推しメン登録モードの場合
+    if (isSelectingFavorite) {
+      const isFavorite = favoriteCardIds.includes(card.id);
+
+      // 既に推しメンの場合は何もしない
+      if (isFavorite) {
+        toast("既に推しメン登録済みです", {
+          icon: "⭐",
+          duration: 2000,
+        });
+        onFavoriteSelected();
+        return;
+      }
+
+      try {
+        setProcessing(true);
+
+        // 推しメン登録（既存の推しメンは自動的に解除される）
+        await addFavoriteCard(user.id, card.id);
+        setFavoriteCardIds([card.id]); // 1人のみ
+
+        toast.success(`${card.name}を推しメンに登録しました！`, {
+          icon: "⭐",
+          duration: 3000,
+        });
+        onFavoriteSelected();
+      } catch (error) {
+        console.error("Failed to update favorite:", error);
+        toast.error("操作に失敗しました");
+        onFavoriteSelected();
+      } finally {
+        setProcessing(false);
+      }
+      return;
+    }
+
+    // 通常モード：カード詳細に遷移
+    toast("カード詳細ページは未実装です", {
+      icon: "ℹ️",
+      duration: 2000,
+    });
+  };
+
+  return (
+    <div>
+      {/* カードグリッド */}
+      <div className="grid grid-cols-3 gap-3">
+        {cards.map((card, index) => (
+          <button
+            key={card.id}
+            type="button"
+            onClick={() => handleCardClick(card)}
+            className={`cursor-pointer transition-all text-left ${
+              processing ? "opacity-50 pointer-events-none" : ""
+            } ${
+              isSelectingFavorite
+                ? "ring-2 ring-yellow-400 ring-offset-2 scale-105"
+                : ""
+            }`}
+          >
+            <Card card={card} label={getLabel(index)} />
+            {favoriteCardIds.includes(card.id) && (
+              <div className="text-center text-yellow-400 text-xs mt-1">
+                ⭐ 推しメン
+              </div>
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+// 推しメン登録ボタンコンポーネント
+export function FavoriteButton({
+  isSelectingFavorite,
+  onToggle,
+  disabled,
+}: {
+  isSelectingFavorite: boolean;
+  onToggle: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      disabled={disabled}
+      className={`px-4 py-2 rounded-lg font-bold transition-all text-sm ${
+        isSelectingFavorite
+          ? "bg-yellow-500 text-white shadow-lg"
+          : "bg-blue-500 text-white hover:bg-blue-600"
+      } ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
+    >
+      {isSelectingFavorite ? "⭐ 選択中" : "推しメン登録"}
+    </button>
+  );
+}

--- a/front/src/app/(authorized)/binder/page.tsx
+++ b/front/src/app/(authorized)/binder/page.tsx
@@ -1,106 +1,14 @@
-"use client";
+import { getCardsFromServer } from "@/lib/server";
+import { BinderContent } from "./BinderContent";
 
-import { useEffect, useState } from "react";
-import Card from "@/components/Card";
-import { useAuth } from "@/context/AuthContext";
-import { getCards } from "@/lib/firestore";
-import type { Card as CardType } from "@/types/app";
-
-export default function BinderPage() {
-  const { user } = useAuth();
-  const [cards, setCards] = useState<CardType[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchCards = async () => {
-      // Only fetch if user logged in and has circleId
-      if (!user?.circleId) {
-        setLoading(false);
-        return;
-      }
-      try {
-        const fetchedCards = await getCards(user.circleId);
-        setCards(fetchedCards);
-      } catch (error) {
-        console.error("Failed to fetch cards", error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    if (user) {
-      fetchCards();
-    } else {
-      // Wait for auth to load
-      if (loading === false && !user) setLoading(false);
-    }
-  }, [user, loading]);
-
-  // ラベル情報を別途管理（最初の3枚に"1st"ラベル）
-  const getLabel = (index: number): string | undefined => {
-    return index < 3 ? "1st" : undefined;
-  };
-
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-gray-950 text-white flex items-center justify-center">
-        Loading...
-      </div>
-    );
-  }
+export default async function BinderPage() {
+  // サーバー側でデータをフェッチ
+  const cards = await getCardsFromServer();
 
   return (
     <div className="min-h-screen bg-gray-950 text-white">
       <div className="mx-auto max-w-md px-4 py-6">
-        {/* Header */}
-        <div className="mb-4">
-          <h1 className="text-2xl font-bold tracking-wide">マイ・バインダー</h1>
-          <p className="text-sm text-gray-400">Total Cards: {cards.length}</p>
-        </div>
-
-        {/* Empty State */}
-        {cards.length === 0 && (
-          <div className="flex flex-col items-center justify-center py-20">
-            <div className="text-gray-400 text-center">
-              <svg
-                className="w-16 h-16 mx-auto mb-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                aria-label="空のバインダーアイコン"
-              >
-                <title>空のバインダーアイコン</title>
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"
-                />
-              </svg>
-              <p className="text-lg font-semibold mb-2">カードがありません</p>
-              <p className="text-sm">
-                カメラから新しいカードを作成してみましょう！
-              </p>
-            </div>
-          </div>
-        )}
-
-        {/* Grid */}
-        {cards.length > 0 && (
-          <div className="grid grid-cols-3 gap-3">
-            {cards.map((card, index) => (
-              <Card
-                key={card.id}
-                card={card}
-                label={getLabel(index)}
-                onClick={(card) => {
-                  console.log("Card clicked:", card);
-                  // TODO: カード詳細ページへの遷移など
-                }}
-              />
-            ))}
-          </div>
-        )}
+        <BinderContent cards={cards} />
       </div>
     </div>
   );

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist_Mono, Orbitron } from "next/font/google";
+import { JetBrains_Mono, Orbitron } from "next/font/google";
 import { Toaster } from "react-hot-toast";
 import "./globals.css";
 import { Footer } from "@/components/layouts/footer";
@@ -11,7 +11,7 @@ const orbitron = Orbitron({
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
+const jetbrainsMono = JetBrains_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
@@ -29,7 +29,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body
-        className={`${orbitron.variable} ${geistMono.variable} antialiased`}
+        className={`${orbitron.variable} ${jetbrainsMono.variable} antialiased`}
       >
         <AuthProvider>
           <Header />

--- a/front/src/components/Card.tsx
+++ b/front/src/components/Card.tsx
@@ -10,17 +10,13 @@ interface CardProps {
 }
 
 export default function Card({ card, label, onClick }: CardProps) {
-  // カード作成からの経過日数を計算
   const getDaysElapsed = (createdAt: Date | string): number => {
     const date =
       typeof createdAt === "string" ? new Date(createdAt) : createdAt;
-
-    // Validate parsed date
     if (Number.isNaN(date.getTime())) {
       console.warn("Invalid date encountered in Card:", createdAt);
       return 0;
     }
-
     const now = new Date();
     const diffTime = Math.abs(now.getTime() - date.getTime());
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
@@ -36,19 +32,16 @@ export default function Card({ card, label, onClick }: CardProps) {
       onClick={() => onClick?.(card)}
     >
       <div className="rounded-xl bg-gray-900/80 p-2">
-        {/* Badge */}
         {label && (
           <span className="absolute -top-1 -left-1 select-none rounded-md bg-cyan-500 px-1.5 py-0.5 text-[10px] font-bold text-black shadow">
             {label}
           </span>
         )}
 
-        {/* 学年バッジ */}
         <div className="absolute top-1 right-1 bg-gradient-to-r from-purple-600/90 to-pink-600/90 px-2 py-0.5 rounded-md text-[10px] font-bold text-white shadow-lg z-10">
           {card.grade}年
         </div>
 
-        {/* Card Image */}
         <div className="aspect-[3/4] rounded-lg bg-gray-800 overflow-hidden relative">
           {card.imageUrl ? (
             <Image
@@ -66,11 +59,9 @@ export default function Card({ card, label, onClick }: CardProps) {
               </div>
             </div>
           )}
-          {/* グラデーションオーバーレイ */}
           <div className="absolute inset-0 bg-gradient-to-t from-gray-900/80 via-transparent to-transparent" />
         </div>
 
-        {/* Card Info */}
         <div className="mt-2 px-1 space-y-1">
           <p className="text-sm font-bold truncate text-white">{card.name}</p>
           <div className="flex items-center justify-between text-[10px]">

--- a/front/src/components/home/CharacterDisplay.tsx
+++ b/front/src/components/home/CharacterDisplay.tsx
@@ -25,7 +25,7 @@ export const CharacterDisplay = ({
       <div className="absolute bottom-0 right-0 w-8 h-8 border-b-2 border-r-2 border-cyan-400 rounded-br-xl z-20" />
 
       {/* キャラクター画像エリア */}
-      <div className="absolute inset-2 top-2 bottom-16 rounded-lg overflow-hidden bg-slate-900/50 z-10 border border-white/10">
+      <div className="absolute inset-2 top-2 bottom-24 rounded-lg overflow-hidden bg-slate-900/50 z-10 border border-white/10">
         {imageUrl ? (
           <Image
             src={imageUrl}
@@ -46,18 +46,18 @@ export const CharacterDisplay = ({
       </div>
 
       {/* 情報パネル */}
-      <div className="absolute bottom-4 left-0 right-0 z-20 flex flex-col items-center">
+      <div className="absolute bottom-2 left-0 right-0 z-20 flex flex-col items-center gap-2 px-2">
         {/* 推しメンラベル */}
-        <div className="mb-2">
-          <span className="text-white font-bold text-lg drop-shadow-[0_0_5px_rgba(255,255,255,0.8)]">
-            推しメン
+        <div className="bg-gradient-to-r from-yellow-500 to-orange-500 px-4 py-1.5 rounded-full shadow-lg">
+          <span className="text-white font-bold text-base drop-shadow-md">
+            ⭐ 推しメン
           </span>
         </div>
 
         {/* パートナー名 */}
-        <div className="w-[90%] bg-black/60 border-t border-b border-cyan-500/50 py-1 text-center backdrop-blur-md">
+        <div className="w-full bg-black/70 border border-cyan-500/50 rounded-lg py-2 px-3 text-center backdrop-blur-md shadow-lg">
           <p className="text-cyan-100 text-sm font-medium tracking-wide">
-            パートナー：{partnerName}
+            {partnerName}
           </p>
         </div>
       </div>

--- a/front/src/types/firestore.ts
+++ b/front/src/types/firestore.ts
@@ -25,6 +25,7 @@ export interface FirestoreUser {
   photoURL?: string;
   bio?: string;
   circleId?: string; // Circle ID
+  favoriteCardIds?: string[]; // 推しメンのカードID配列
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }


### PR DESCRIPTION
## 概要
ホーム画面の推しメン選択機能追加

## チケットへのリンク
https://github.com/jyogi-web/2025_Ptera/issues/78

## マージを希望するか
- [x] 希望する
- [] 希望しない

## 行った作業
- 推しメン選択機能
- なぞに出てたエラー（ボタン関係だった）の修正
- 

## 動作確認
* 推しメンを選択するとホームに表示される
* 切り替えると変わり、前に登録したのは解除される

## その他
コンフリクト起きそう

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * バインダーに新しいカード一覧表示と選択的「推し」登録UIを追加しました。
  * サーバー側でカード一覧を取得するようになり、初期表示が高速化しました。
  * ホームにユーザーの現在の推しカードを動的に表示します。
  * 推し管理（登録・解除・取得）を行うAPIを追加しました。

* **スタイル**
  * キャラクター表示のレイアウトとバッジデザインを改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->