### PR TITLE
fix ヘッダー調整

### DIFF
--- a/front/src/components/layouts/header/HeaderStatusPanel.tsx
+++ b/front/src/components/layouts/header/HeaderStatusPanel.tsx
@@ -2,42 +2,40 @@
 
 import { Animator } from "@arwes/react";
 import { memo } from "react";
+import { calculateGraduationDate } from "@/helper/converter";
+import type { Card } from "@/types/app";
 
 export type HeaderStatusPanelProps = {
   active: boolean;
-  rank: number;
-  cp: number;
-  maxRank?: number;
-};
-
-const RANK_THRESHOLDS = {
-  DIRECTOR: 40,
-  VICE_DIRECTOR: 30,
-  DEPUTY: 20,
-  MEMBER: 10,
-} as const;
-
-const getRankTitle = (rank: number): string => {
-  if (rank >= RANK_THRESHOLDS.DIRECTOR) return "部長級";
-  if (rank >= RANK_THRESHOLDS.VICE_DIRECTOR) return "副部長級";
-  if (rank >= RANK_THRESHOLDS.DEPUTY) return "副部級";
-  if (rank >= RANK_THRESHOLDS.MEMBER) return "部員級";
-  return "新入部員";
+  favorite?: Card | null;
 };
 
 export const HeaderStatusPanel = memo(
-  ({ active, rank = 0, cp = 0, maxRank = 50 }: HeaderStatusPanelProps) => {
-    const rankTitle = getRankTitle(rank);
-    const progressPercent = Math.min(
-      100,
-      Math.max(0, maxRank > 0 ? (rank / maxRank) * 100 : 0),
-    );
+  ({ active, favorite }: HeaderStatusPanelProps) => {
+    // Compute remaining days until graduation for favorite card
+    let favoriteLabel = "推しメン: 未設定";
+
+    if (favorite) {
+      try {
+        const grad = calculateGraduationDate(favorite.grade);
+        const now = new Date();
+        const diff = Math.ceil(
+          (grad.getTime() - now.getTime()) / (1000 * 60 * 60 * 24),
+        );
+        const days = Math.max(0, diff);
+        favoriteLabel = `${favorite.name} (${favorite.grade}年) — ${days > 0 ? `卒業まで${days}日` : "卒業済み"}`;
+      } catch (e) {
+        console.error("Failed to compute graduation for favorite:", e);
+        favoriteLabel = `${favorite.name} (${favorite.grade}年)`;
+      }
+    }
+
     return (
       <Animator active={active}>
         <section
           className="relative flex-1 w-full min-w-[200px] h-16 text-white -mr-4 z-10"
           style={{ filter: "drop-shadow(0 0 1px cyan)" }}
-          aria-label="User Status"
+          aria-label="Favorite Status"
         >
           <div
             className="h-full px-4 flex flex-col justify-center bg-gradient-to-r from-blue-900/90 to-cyan-900/90"
@@ -46,33 +44,8 @@ export const HeaderStatusPanel = memo(
             }}
           >
             <div className="relative z-10 flex flex-col space-y-0.5 pr-4">
-              {/* ランク */}
-              <div className="flex justify-between items-baseline">
-                <div className="font-bold text-cyan-100 text-xs md:text-sm whitespace-nowrap">
-                  Rank:{" "}
-                  <span className="text-white text-sm md:text-base">
-                    {rank}
-                  </span>
-                  <span className="text-xs text-cyan-300">（{rankTitle}）</span>
-                </div>
-              </div>
-              {/* プログレスバー */}
-              <div
-                className="h-1.5 w-full bg-cyan-900/50 rounded-full overflow-hidden my-0.5"
-                role="progressbar"
-                aria-valuemin={0}
-                aria-valuemax={maxRank}
-                aria-valuenow={rank}
-                aria-label="Rank Progress"
-              >
-                <div
-                  className="h-full bg-gradient-to-r from-cyan-400 to-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.8)]"
-                  style={{ width: `${progressPercent}%` }}
-                ></div>
-              </div>
-              {/* 部費 */}
-              <div className="text-xs md:text-sm text-cyan-200 font-mono whitespace-nowrap">
-                部費 : {cp} CP
+              <div className="font-bold text-cyan-100 text-xs md:text-sm truncate">
+                {favoriteLabel}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## 概要
ヘッダーを推しメンの情報にした

## チケットへのリンク
https://github.com/jyogi-web/2025_Ptera/issues/95

## マージを希望するか
- [x] 希望する
- [] 希望しない

## 行った作業
- ヘッダーのモックデータを推しメンのデータから取得して表示
- 推しメンを変えるとヘッダーが更新されて変更される
- 

## 動作確認
* 推しメンを変えると更新が入る
<img width="1895" height="461" alt="image" src="https://github.com/user-attachments/assets/91610aac-03e2-4e49-9091-96a778d36451" />
<img width="558" height="689" alt="image" src="https://github.com/user-attachments/assets/2c91cda9-7599-4b1c-ac07-22d30f0a4660" />
<img width="1909" height="459" alt="image" src="https://github.com/user-attachments/assets/ba2d4a07-8c1a-4e16-921c-a58b4e79782d" />

## その他
おいらがやるしか　ねぇなぁ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ヘッダーでお気に入りカード情報をリアルタイムで表示するように変更しました
  * お気に入りカードの卒業予定日までの日数を自動計算し表示します
  * ユーザーステータス表示がランク/CP ベースからお気に入りカード中心の表示に更新されました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->