### PR TITLE
feat 詳細機能

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -575,7 +575,8 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
       "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@bufbuild/protoc-gen-es": {
       "version": "1.10.1",
@@ -583,6 +584,7 @@
       "integrity": "sha512-YADugbvibIdZSb0NGf5OF87IyKTuMvMFZ7vMHgm6pL1SCfDwJ/ZRianTdrPG9hq/gOipK+NwHmXBViyS3J7nxA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@bufbuild/protobuf": "^1.10.1",
         "@bufbuild/protoplugin": "1.10.1"
@@ -633,6 +635,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
       "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0"
       }
@@ -1203,6 +1206,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.6.tgz",
       "integrity": "sha512-4uyt8BOrBsSq6i4yiOV/gG6BnnrvTeyymlNcaN/dKvyU1GoolxAafvIvaNP1RCGPlNab3OuE4MKUQuv2lH+PLQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -1269,6 +1273,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.6.tgz",
       "integrity": "sha512-YYGARbutghQY4zZUWMYia0ib0Y/rb52y72/N0z3vglRHL7ii/AaK9SA7S/dzScVOlCdnbHXz+sc5Dq+r8fwFAg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.6",
         "@firebase/component": "0.7.0",
@@ -1284,7 +1289,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.0",
@@ -1735,6 +1741,7 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3418,6 +3425,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3854,7 +3862,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -5216,6 +5225,7 @@
       "resolved": "https://registry.npmjs.org/motion/-/motion-10.18.0.tgz",
       "integrity": "sha512-MVAZZmwM/cp77BrNe1TxTMldxRPjwBNHheU5aPToqT4rJdZxLiADk58H+a0al5jKLxkB0OdgNq6DiVn11cjvIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@motionone/animation": "^10.18.0",
         "@motionone/dom": "^10.18.0",
@@ -5467,6 +5477,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5637,6 +5648,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5646,6 +5658,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6139,6 +6152,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6200,6 +6214,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/front/src/app/(authorized)/binder/_components/BinderCard.tsx
+++ b/front/src/app/(authorized)/binder/_components/BinderCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import type { Card } from "@/types/app";
 import { styles } from "../_styles/BinderCard.styles";

--- a/front/src/app/(authorized)/binder/_components/BinderGrid.tsx
+++ b/front/src/app/(authorized)/binder/_components/BinderGrid.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useCallback, useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import Modal from "@/components/ui/Modal";
@@ -142,6 +143,23 @@ export function BinderGrid({
       <Modal isOpen={isModalOpen} onClose={closeModal} title="カード詳細">
         {selectedCard ? (
           <div>
+            {selectedCard.imageUrl ? (
+              <div className="mb-4 relative w-full h-64 rounded-md overflow-hidden">
+                <Image
+                  src={selectedCard.imageUrl}
+                  alt={selectedCard.name}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 640px) 100vw, 640px"
+                />
+              </div>
+            ) : (
+              <div
+                className="mb-4 w-full max-h-64 bg-slate-800 rounded-md"
+                aria-hidden
+              />
+            )}
+
             <div className="mb-2 text-lg font-bold text-slate-100">
               {selectedCard.name}
             </div>
@@ -165,11 +183,7 @@ export function BinderGrid({
                 学科: {selectedCard.department}
               </div>
             )}
-            {selectedCard.memo && (
-              <div className="mt-3 text-sm whitespace-pre-wrap text-slate-200">
-                {selectedCard.memo}
-              </div>
-            )}
+            {/* memo field removed — using `description` for comments */}
             {selectedCard.description && (
               <div className="mt-3 text-sm whitespace-pre-wrap text-slate-200">
                 <div className="text-xs text-slate-400 mb-1">作成コメント</div>

--- a/front/src/app/(authorized)/binder/_components/BinderGrid.tsx
+++ b/front/src/app/(authorized)/binder/_components/BinderGrid.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
+import Modal from "@/components/ui/Modal";
 import { useAuth } from "@/context/AuthContext";
 import { addFavoriteCard, getFavoriteCards } from "@/lib/firestore";
 import type { Card as CardType } from "@/types/app";
@@ -36,6 +39,30 @@ export function BinderGrid({
     loadFavorites();
   }, [user]);
 
+  // modal state
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedCard, setSelectedCard] = useState<CardType | null>(null);
+
+  const renderExpiry = () => {
+    if (!selectedCard || !selectedCard.expiryDate) return null;
+    const expiry = new Date(selectedCard.expiryDate);
+    const now = new Date();
+    const diffMs = expiry.getTime() - now.getTime();
+    const daysLeft = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+
+    return (
+      <div className="mt-2 text-sm text-slate-300">
+        卒業: {expiry.toLocaleDateString()}{" "}
+        {daysLeft > 0 ? `（あと ${daysLeft}日）` : "（卒業済み）"}
+      </div>
+    );
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setSelectedCard(null);
+  };
+
   const handleCardClick = async (card: CardType) => {
     if (!user || processing) return;
 
@@ -61,7 +88,7 @@ export function BinderGrid({
           duration: 3000,
           style: {
             ...cyberToastStyle,
-            border: "1px solid #facc15", // Yellow border for success
+            border: "1px solid #facc15",
             color: "#fef08a",
             boxShadow: "0 0 15px rgba(250, 204, 21, 0.3)",
           },
@@ -72,7 +99,7 @@ export function BinderGrid({
         toast.error("操作に失敗しました", {
           style: {
             ...cyberToastStyle,
-            border: "1px solid #ef4444", // Red border for error
+            border: "1px solid #ef4444",
             color: "#fecaca",
             boxShadow: "0 0 15px rgba(239, 68, 68, 0.3)",
           },
@@ -84,11 +111,9 @@ export function BinderGrid({
       return;
     }
 
-    toast("カード詳細ページは未実装です", {
-      icon: "",
-      duration: 2000,
-      style: cyberToastStyle,
-    });
+    // open detail modal
+    setSelectedCard(card);
+    setIsModalOpen(true);
   };
 
   return (
@@ -113,31 +138,62 @@ export function BinderGrid({
           </div>
         ))}
       </div>
-    </div>
-  );
-}
 
-export function FavoriteButton({
-  isSelectingFavorite,
-  onToggle,
-  disabled,
-}: {
-  isSelectingFavorite: boolean;
-  onToggle: () => void;
-  disabled: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onToggle}
-      disabled={disabled}
-      className={`px-4 py-2 rounded-lg font-bold transition-all text-sm ${
-        isSelectingFavorite
-          ? "bg-yellow-500 text-white shadow-lg"
-          : "bg-blue-500 text-white hover:bg-blue-600"
-      } ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
-    >
-      {isSelectingFavorite ? " 選択中" : "推しメン登録"}
-    </button>
+      <Modal isOpen={isModalOpen} onClose={closeModal} title="カード詳細">
+        {selectedCard ? (
+          <div>
+            <div className="mb-2 text-lg font-bold text-slate-100">
+              {selectedCard.name}
+            </div>
+            <div className="mb-1 text-sm text-slate-300">
+              {typeof selectedCard.grade === "number"
+                ? `${selectedCard.grade}年`
+                : selectedCard.grade}
+            </div>
+            {selectedCard.position && (
+              <div className="mb-2 text-sm text-slate-300">
+                役職: {selectedCard.position}
+              </div>
+            )}
+            {selectedCard.faculty && (
+              <div className="mb-2 text-sm text-slate-300">
+                学部: {selectedCard.faculty}
+              </div>
+            )}
+            {selectedCard.department && (
+              <div className="mb-2 text-sm text-slate-300">
+                学科: {selectedCard.department}
+              </div>
+            )}
+            {selectedCard.memo && (
+              <div className="mt-3 text-sm whitespace-pre-wrap text-slate-200">
+                {selectedCard.memo}
+              </div>
+            )}
+            {selectedCard.description && (
+              <div className="mt-3 text-sm whitespace-pre-wrap text-slate-200">
+                <div className="text-xs text-slate-400 mb-1">作成コメント</div>
+                <div>{selectedCard.description}</div>
+              </div>
+            )}
+            {renderExpiry()}
+            {selectedCard.createdAt && (
+              <div className="mt-3 text-xs text-slate-400">
+                作成: {new Date(selectedCard.createdAt).toLocaleString()}
+              </div>
+            )}
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                onClick={closeModal}
+                className="px-3 py-1 rounded bg-white/5 hover:bg-white/10 text-slate-100"
+              >
+                閉じる
+              </button>
+            </div>
+          </div>
+        ) : null}
+      </Modal>
+    </div>
   );
 }

--- a/front/src/app/(authorized)/binder/_components/BinderGrid.tsx
+++ b/front/src/app/(authorized)/binder/_components/BinderGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import Modal from "@/components/ui/Modal";
 import { useAuth } from "@/context/AuthContext";
@@ -58,10 +58,10 @@ export function BinderGrid({
     );
   };
 
-  const closeModal = () => {
+  const closeModal = useCallback(() => {
     setIsModalOpen(false);
     setSelectedCard(null);
-  };
+  }, []);
 
   const handleCardClick = async (card: CardType) => {
     if (!user || processing) return;

--- a/front/src/app/(authorized)/binder/_styles/page.styles.ts
+++ b/front/src/app/(authorized)/binder/_styles/page.styles.ts
@@ -13,7 +13,7 @@ export const styles: { [key: string]: CSSProperties } = {
     overflow: "hidden", // Prevent scrolling on the body/container
     touchAction: "pan-y", // Allow vertical pan, prevent bounce scroll where supported/needed
     fontFamily: '"Segoe UI", Roboto, Helvetica, Arial, sans-serif',
-    color: "#a4b5c9",
+    color: "#e6fdf9",
     background: "#050b14",
     display: "flex",
     flexDirection: "column",
@@ -56,14 +56,14 @@ export const styles: { [key: string]: CSSProperties } = {
     boxShadow: "0 0 10px rgba(6, 182, 212, 0.1)", // Subtle cyan glow
   },
   totalCardsLabel: {
-    color: "#64748b", // slate-500
+    color: "#94a3b8", // slightly brighter slate
     fontSize: "0.75rem",
     textTransform: "uppercase",
     letterSpacing: "0.05em",
     fontFamily: "monospace",
   },
   totalCardsValue: {
-    color: "#22d3ee", // cyan-400
+    color: "#7ef9f1", // brighter cyan for contrast
     fontSize: "1rem",
     fontWeight: "bold",
     fontFamily: "monospace",

--- a/front/src/components/ui/Modal.tsx
+++ b/front/src/components/ui/Modal.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { FrameCorners } from "@arwes/react";
+import { useEffect } from "react";
+import ReactDOM from "react-dom";
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children?: React.ReactNode;
+}
+
+export default function Modal({
+  isOpen,
+  onClose,
+  title,
+  children,
+}: ModalProps) {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKey);
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleKey);
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const modal = (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onMouseDown={onClose}
+        aria-hidden
+      />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="relative max-w-2xl w-full mx-auto z-10"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="relative">
+          <FrameCorners
+            strokeWidth={1}
+            cornerLength={16}
+            style={{ color: "#00dac1", backgroundColor: "transparent" }}
+          />
+
+          <div className="relative bg-[rgba(3,15,25,0.92)] border border-cyan-600/20 shadow-[0_0_30px_rgba(34,211,238,0.06)] rounded-lg p-6 text-slate-200">
+            <div className="absolute top-3 right-3">
+              <button
+                type="button"
+                aria-label="閉じる"
+                onClick={onClose}
+                className="w-8 h-8 flex items-center justify-center rounded hover:bg-white/5"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  className="w-4 h-4"
+                >
+                  <title>閉じる</title>
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            {title && (
+              <div className="mb-4 text-lg font-semibold text-[#e6fdf9]">
+                {title}
+              </div>
+            )}
+            <div>{children}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  const target = typeof document !== "undefined" ? document.body : null;
+  return target ? ReactDOM.createPortal(modal, target) : null;
+}

--- a/front/src/types/app.ts
+++ b/front/src/types/app.ts
@@ -21,6 +21,9 @@ export interface Card {
   name: string; // 名前
   grade: number; // 学年
   position: string; // 役割
+  faculty?: string; // 学部
+  department?: string; // 学科
+  memo?: string; // メモや補足
   affiliatedGroup?: string; // サークル名 (Legacy/Display purpose)
   circleId?: string; // Circle ID (System)
   hobby: string; // 趣味

--- a/front/src/types/app.ts
+++ b/front/src/types/app.ts
@@ -23,7 +23,6 @@ export interface Card {
   position: string; // 役割
   faculty?: string; // 学部
   department?: string; // 学科
-  memo?: string; // メモや補足
   affiliatedGroup?: string; // サークル名 (Legacy/Display purpose)
   circleId?: string; // Circle ID (System)
   hobby: string; // 趣味


### PR DESCRIPTION
## 概要
カード押したときに詳細が表示される

## チケットへのリンク
https://github.com/jyogi-web/2025_Ptera/issues/18

## マージを希望するか
- [x] 希望する
- [] 希望しない

## 行った作業
-クリックしたとき カードの詳細表示機能


## 動作確認
* 推したら表示される
<img width="1094" height="604" alt="image" src="https://github.com/user-attachments/assets/6111ade6-651c-47ab-a864-faca091b1633" />

## その他

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * カードクリックで詳細がモーダル表示されるようになりました（画像、名前、成績/年次、説明、有効期限、作成日など）。

* **データ**
  * カードに「所属」「部門」の任意フィールドが追加され、詳細表示で確認できます。

* **スタイル**
  * バインダーページの配色を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->