### PR TITLE
feat カード失効機能追加

### DIFF
--- a/front/src/lib/expiry.test.ts
+++ b/front/src/lib/expiry.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { isExpired, daysUntil } from "./expiry";
+import { describe, expect, it } from "vitest";
+import { daysUntil, isExpired } from "./expiry";
 
 describe("expiry utilities", () => {
   it("returns true for past dates", () => {

--- a/front/src/lib/expiry.test.ts
+++ b/front/src/lib/expiry.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { isExpired, daysUntil } from "./expiry";
+
+describe("expiry utilities", () => {
+  it("returns true for past dates", () => {
+    const now = new Date("2025-12-21T00:00:00.000Z");
+    const past = new Date("2020-01-01T00:00:00.000Z");
+    expect(isExpired(past, now)).toBe(true);
+  });
+
+  it("returns false for future dates", () => {
+    const now = new Date("2025-12-21T00:00:00.000Z");
+    const future = new Date("2026-01-01T00:00:00.000Z");
+    expect(isExpired(future, now)).toBe(false);
+  });
+
+  it("calculates days until correctly for future date", () => {
+    const now = new Date("2025-12-21T00:00:00.000Z");
+    const future = new Date("2025-12-26T00:00:00.000Z");
+    expect(daysUntil(future, now)).toBe(5);
+  });
+
+  it("returns 0 or negative for same-day or past dates", () => {
+    const now = new Date("2025-12-21T12:00:00.000Z");
+    const sameDay = new Date("2025-12-21T00:00:00.000Z");
+    expect(daysUntil(sameDay, now)).toBeLessThanOrEqual(0);
+  });
+});

--- a/front/src/lib/expiry.ts
+++ b/front/src/lib/expiry.ts
@@ -1,20 +1,28 @@
 /**
  * Utility helpers for expiry date handling used by server-side filtering.
  */
-export function parseToDate(input: Date | string | undefined | null): Date | null {
+export function parseToDate(
+  input: Date | string | undefined | null,
+): Date | null {
   if (!input) return null;
   if (input instanceof Date) return input;
   const d = new Date(input);
   return Number.isNaN(d.getTime()) ? null : d;
 }
 
-export function isExpired(input: Date | string | undefined | null, now: Date = new Date()): boolean {
+export function isExpired(
+  input: Date | string | undefined | null,
+  now: Date = new Date(),
+): boolean {
   const d = parseToDate(input);
   if (!d) return false; // treat invalid/missing expiry as not expired (handled elsewhere)
   return d.getTime() <= now.getTime();
 }
 
-export function daysUntil(input: Date | string | undefined | null, now: Date = new Date()): number | null {
+export function daysUntil(
+  input: Date | string | undefined | null,
+  now: Date = new Date(),
+): number | null {
   const d = parseToDate(input);
   if (!d) return null;
   const diffMs = d.getTime() - now.getTime();

--- a/front/src/lib/expiry.ts
+++ b/front/src/lib/expiry.ts
@@ -1,0 +1,24 @@
+/**
+ * Utility helpers for expiry date handling used by server-side filtering.
+ */
+export function parseToDate(input: Date | string | undefined | null): Date | null {
+  if (!input) return null;
+  if (input instanceof Date) return input;
+  const d = new Date(input);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export function isExpired(input: Date | string | undefined | null, now: Date = new Date()): boolean {
+  const d = parseToDate(input);
+  if (!d) return false; // treat invalid/missing expiry as not expired (handled elsewhere)
+  return d.getTime() <= now.getTime();
+}
+
+export function daysUntil(input: Date | string | undefined | null, now: Date = new Date()): number | null {
+  const d = parseToDate(input);
+  if (!d) return null;
+  const diffMs = d.getTime() - now.getTime();
+  return Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+}
+
+export default { parseToDate, isExpired, daysUntil };


### PR DESCRIPTION
## 概要
学年に応じた卒業日にカードが失効するようにした


## チケットへのリンク
https://github.com/jyogi-web/2025_Ptera/issues/100
## マージを希望するか
- [x] 希望する
- [] 希望しない

## 行った作業
- 四年後（各カードの学年設定時）にカードの失効

## 動作確認
* テストコード突っ込んでテストで試した

## その他
実際に四年経って試したわけじゃない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * カードの有効期限判定機能を追加し、期限切れのカードは自動的に結果から除外されます。
  * 日付入力を扱う有効期限ユーティリティ（日時変換・期限判定・残日数計算）を追加しました。

* **不具合修正 / 安定性**
  * 期限の解析に失敗してもカードを誤って除外しないようにし、解析エラー時は警告を出力して復元性を保ちます。

* **テスト**
  * 有効期限ユーティリティの単体テストを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->