### PR TITLE
feat ふったぁヲ剣にした

### DIFF
--- a/front/src/components/layouts/footer/index.tsx
+++ b/front/src/components/layouts/footer/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Animator, AnimatorGeneralProvider } from "@arwes/react";
-import { Book, Home, Rocket, Users } from "lucide-react";
+import { Book, Home, Sword, Users } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useAuth } from "@/context/AuthContext";
@@ -24,9 +24,9 @@ const FOOTER_ITEMS = [
     icon: Users,
   },
   {
-    label: "ガチャ",
-    href: "/gacha",
-    icon: Rocket,
+    label: "Battle",
+    href: "/circle/matching",
+    icon: Sword,
   },
 ];
 

--- a/front/src/components/layouts/footer/index.tsx
+++ b/front/src/components/layouts/footer/index.tsx
@@ -24,7 +24,7 @@ const FOOTER_ITEMS = [
     icon: Users,
   },
   {
-    label: "Battle",
+    label: "バトル",
     href: "/circle/matching",
     icon: Sword,
   },

--- a/front/src/components/layouts/footer/index.tsx
+++ b/front/src/components/layouts/footer/index.tsx
@@ -45,7 +45,9 @@ export const Footer = () => {
 
   // 特定のパスで非表示にする場合はここに追加
   const isHiddenPath =
-    ["/login", "/"].includes(pathname) || pathname.startsWith("/battle");
+    ["/login", "/"].includes(pathname) ||
+    pathname.startsWith("/battle") ||
+    pathname.startsWith("/circle/matching");
   if (isHiddenPath) return null;
 
   return (


### PR DESCRIPTION
## 概要
実装しないガチャ➡バトルへの遷移リンクへ変更
## チケットへのリンク
https://github.com/jyogi-web/2025_Ptera/issues/124

## マージを希望するか
- [x] 希望する
- [] 希望しない

## 行った作業
- フッター変更
- イラスト変更
- 

## 動作確認
* 対戦準備画面へ遷移
* 
<img width="1024" height="202" alt="image" src="https://github.com/user-attachments/assets/00e64dee-d8ac-4ba9-8216-5ad0c87ce634" />


## その他
（実装上の懸念点や注意点などあれば記載）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * フッターメニューの「ガチャ」を「バトル」に差し替え、プレイヤーマッチングへの直接アクセスを追加しました。アクティブ状態の表示は引き続き適切に反映されます。
* **改善**
  * フッターの表示制御を拡張し、特定の画面（ログインやルート以外にバトル／マッチング画面）でフッターを非表示にするよう調整しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->