### PR TITLE
fix 仮データの内容変更

### DIFF
--- a/front/src/components/layouts/header/index.tsx
+++ b/front/src/components/layouts/header/index.tsx
@@ -32,7 +32,7 @@ export const Header = (): React.JSX.Element | null => {
   // 現在はモックデータを使用しています
   // 今後、以下のデータをAuthContextまたはAPIから取得する必要があります
   const mockUserStats: UserStats = {
-    grade: "大学3年目",
+    grade: "大学ーー年目",
     rank: 42,
     cp: 15000,
   };


### PR DESCRIPTION
## 概要
仮で三年目のデータだったから変えた
## チケットへのリンク
https://github.com/jyogi-web/2025_Ptera/issues/125
## マージを希望するか
- [x] 希望する
- [] 希望しない

## 行った作業
- 三年目➡--年目に変更

## 動作確認
* ログインデータを消してログイン前の状態から見た
<img width="1919" height="235" alt="スクリーンショット 2025-12-21 080506" src="https://github.com/user-attachments/assets/3018f767-d81a-490c-b374-96938ad69195" />

## その他
（実装上の懸念点や注意点などあれば記載）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * ヘッダーコンポーネントのモック表示データを更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->